### PR TITLE
Only enable direct redemptions during oracle outages

### DIFF
--- a/packages/contracts/contracts/Interfaces/IPriceFeed.sol
+++ b/packages/contracts/contracts/Interfaces/IPriceFeed.sol
@@ -6,7 +6,18 @@ interface IPriceFeed {
 
     // --- Events ---
     event LastGoodPriceUpdated(uint256 _lastGoodPrice);
+
+    enum Status {
+        active,
+        stale,
+        disabled
+    }
+    
+    struct FetchPriceResponse {
+        Status status;
+        uint price;
+    }
    
     // --- Function ---
-    function fetchPrice() external returns (uint);
+    function fetchPrice() external returns (FetchPriceResponse memory);
 }

--- a/packages/contracts/contracts/Proxy/BorrowerWrappersScript.sol
+++ b/packages/contracts/contracts/Proxy/BorrowerWrappersScript.sol
@@ -127,10 +127,10 @@ contract BorrowerWrappersScript is BorrowerOperationsScript, ETHTransferScript, 
     }
 
     function _getNetTHUSDAmount(uint256 _collateral) internal returns (uint) {
-        uint256 price = priceFeed.fetchPrice();
-        uint256 ICR = troveManager.getCurrentICR(address(this), price);
+        IPriceFeed.FetchPriceResponse memory priceFeedResponse = priceFeed.fetchPrice();
+        uint256 ICR = troveManager.getCurrentICR(address(this), priceFeedResponse.price);
 
-        uint256 THUSDAmount = _collateral * price / ICR;
+        uint256 THUSDAmount = _collateral * priceFeedResponse.price / ICR;
         uint256 borrowingRate = troveManager.getBorrowingRateWithDecay();
         uint256 netDebt = THUSDAmount * LiquityMath.DECIMAL_PRECISION / (LiquityMath.DECIMAL_PRECISION + borrowingRate);
 

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -633,9 +633,9 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, SendCollateral, I
     }
 
     function _requireNoUnderCollateralizedTroves() internal {
-        uint256 price = priceFeed.fetchPrice();
+        IPriceFeed.FetchPriceResponse memory priceFeedResponse = priceFeed.fetchPrice();
         address lowestTrove = sortedTroves.getLast();
-        uint256 ICR = troveManager.getCurrentICR(lowestTrove, price);
+        uint256 ICR = troveManager.getCurrentICR(lowestTrove, priceFeedResponse.price);
         require(ICR >= MCR, "StabilityPool: Cannot withdraw while there are troves with ICR < MCR");
     }
 

--- a/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
+++ b/packages/contracts/contracts/TestContracts/PriceFeedTestnet.sol
@@ -32,11 +32,14 @@ contract PriceFeedTestnet is Ownable, IPriceFeed {
         return _price;
     }
 
-    function fetchPrice() external override returns (uint256) {
+    function fetchPrice() external override returns (IPriceFeed.FetchPriceResponse memory) {
+        IPriceFeed.FetchPriceResponse memory response;
         // Fire an event just like the mainnet version would.
         // This lets the subgraph rely on events to get the latest price even when developing locally.
         emit LastGoodPriceUpdated(_price);
-        return _price;
+        response.status = IPriceFeed.Status.active;
+        response.price = _price;
+        return response;
     }
 
     // Manual external price setter.

--- a/packages/lib-ethers/abi/PriceFeed.json
+++ b/packages/lib-ethers/abi/PriceFeed.json
@@ -215,9 +215,21 @@
     "name": "fetchPrice",
     "outputs": [
       {
-        "internalType": "uint256",
+        "components": [
+          {
+            "internalType": "enum IPriceFeed.Status",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IPriceFeed.FetchPriceResponse",
         "name": "",
-        "type": "uint256"
+        "type": "tuple"
       }
     ],
     "stateMutability": "nonpayable",

--- a/packages/lib-ethers/abi/PriceFeedTestnet.json
+++ b/packages/lib-ethers/abi/PriceFeedTestnet.json
@@ -49,9 +49,21 @@
     "name": "fetchPrice",
     "outputs": [
       {
-        "internalType": "uint256",
+        "components": [
+          {
+            "internalType": "enum IPriceFeed.Status",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IPriceFeed.FetchPriceResponse",
         "name": "",
-        "type": "uint256"
+        "type": "tuple"
       }
     ],
     "stateMutability": "nonpayable",

--- a/packages/lib-ethers/src/ReadableEthersLiquity.ts
+++ b/packages/lib-ethers/src/ReadableEthersLiquity.ts
@@ -218,7 +218,8 @@ export class ReadableEthersLiquity implements ReadableLiquity {
   /** {@inheritDoc @liquity/lib-base#ReadableLiquity.getPrice} */
   getPrice(overrides?: EthersCallOverrides): Promise<Decimal> {
     const { priceFeed } = _getContracts(this.connection);
-    return priceFeed.callStatic.fetchPrice({ ...overrides }).then(decimalify);
+    return priceFeed.callStatic.fetchPrice({ ...overrides })
+      .then((value: { status: number, price: BigNumber}) => decimalify(value.price));
     // TODO Swap once we redeploy the contracts
     //return priceFeed.callStatic.getRedemptionPrice({ ...overrides }).then(decimalify);
   }
@@ -373,9 +374,9 @@ export class ReadableEthersLiquity implements ReadableLiquity {
       ? stake.mul(bammCollateralBalance).div(total) 
       : BigNumber.from(0)
     
-    const price = await priceFeed.callStatic.fetchPrice({ ...overrides })
+    const result = await priceFeed.callStatic.fetchPrice({ ...overrides })
 
-    const currentUSD = currentTHUSD.add(currentCollateral.mul(price).div(_1e18))
+    const currentUSD = currentTHUSD.add(currentCollateral.mul(result.price).div(_1e18))
 
     const bammPoolShare = isTotalGreaterThanZero 
       ? Decimal.fromBigNumber(stake).mulDiv(100, Decimal.fromBigNumber(total)) 

--- a/packages/lib-ethers/types/index.ts
+++ b/packages/lib-ethers/types/index.ts
@@ -582,7 +582,7 @@ interface PriceFeedCalls {
 }
 
 interface PriceFeedTransactions {
-  fetchPrice(_overrides?: Overrides): Promise<BigNumber>;
+  fetchPrice(_overrides?: Overrides): Promise<{ status: number; price: BigNumber }>;
   getRedemptionPrice(_overrides?: Overrides): Promise<BigNumber>;
   setAddresses(_ledAddress: string, _pidCalculatorAddress: string, _uniV3ReaderAddress: string, _overrides?: Overrides): Promise<void>;
   setUniV3PoolAddress(_uniV3PoolAddress: string, _overrides?: Overrides): Promise<void>;
@@ -620,7 +620,7 @@ interface PriceFeedTestnetCalls {
 }
 
 interface PriceFeedTestnetTransactions {
-  fetchPrice(_overrides?: Overrides): Promise<BigNumber>;
+  fetchPrice(_overrides?: Overrides): Promise<{ status: number; price: BigNumber }>;
   setAddresses(a1: string, a2: string, a3: string, _overrides?: Overrides): Promise<void>;
   setPrice(price: BigNumberish, _overrides?: Overrides): Promise<boolean>;
   transferOwnership(newOwner: string, _overrides?: Overrides): Promise<void>;


### PR DESCRIPTION
Migrating previous PR to new repo. I had to change some unrelated params to be structs due to solidity's "stack too deep" error: https://soliditydeveloper.com/stacktoodeep