### PR TITLE
Embed Uniswap in the FE

### DIFF
--- a/packages/dev-frontend/src/ThresholdFrontend.tsx
+++ b/packages/dev-frontend/src/ThresholdFrontend.tsx
@@ -16,6 +16,7 @@ import { RedemptionPage } from "./pages/RedemptionPage";
 import { RiskyVaultsPage } from "./pages/RiskyVaultsPage";
 
 import { VaultPage } from "./pages/VaultPage";
+import { SwapPage } from "./pages/SwapPage";
 
 import { ThresholdProvider } from "./hooks/ThresholdContext";
 import { StabilityPoolPage } from "./pages/StabilityPoolPage";
@@ -95,6 +96,9 @@ export const ThresholdFrontend = ({ loader }: ThresholdFrontendProps): JSX.Eleme
                         </Route>
                         <Route path="/borrow" exact>
                           <VaultPage />
+                        </Route>
+                        <Route path="/swap" exact>
+                          <SwapPage />
                         </Route>
                         <Route path="/earn" exact>
                           <StabilityPoolPage />

--- a/packages/dev-frontend/src/components/Nav.tsx
+++ b/packages/dev-frontend/src/components/Nav.tsx
@@ -29,6 +29,12 @@ export const Nav = (): JSX.Element => {
           </Flex>
           Borrow
         </Link>
+        <Link to="/swap" >
+          <Flex>
+            <Icon name="exchange-alt" />
+          </Flex>
+          Swap
+        </Link>
         <Link to="/earn">
           <Icon name="chart-line" />
           Earn

--- a/packages/dev-frontend/src/pages/SwapPage.tsx
+++ b/packages/dev-frontend/src/pages/SwapPage.tsx
@@ -11,9 +11,11 @@ export const SwapPage = (): JSX.Element => {
   const selector = ({
     symbol,
     collateralAddress,
+    stableAddress
   }: ThresholdStoreState) => ({
     symbol,
     collateralAddress,
+    stableAddress
   });
 
   const thresholdSelectorStores = useThresholdSelector(selector);
@@ -21,6 +23,7 @@ export const SwapPage = (): JSX.Element => {
   const store = thresholdStore?.store!;
   const symbol = store.symbol;
   const collateralAddress = store.collateralAddress;
+  const stableAddress = store.stableAddress;
   const [colorMode] = useColorMode();
   
   return (
@@ -40,7 +43,7 @@ export const SwapPage = (): JSX.Element => {
           width: "95%",
           mt: "2em"
         }}
-        src={`https://app.uniswap.org/#/swap?inputCurrency=${collateralAddress}&outputCurrency=0x1091221BbF69ae494ae7d5fE7c794A361e89850c&theme=${colorMode == "default" ? "light" : "dark"}`}
+        src={`https://app.uniswap.org/#/swap?inputCurrency=${collateralAddress}&outputCurrency=${stableAddress}&theme=${colorMode == "default" ? "light" : "dark"}`}
       />
     </Container>
   );

--- a/packages/dev-frontend/src/pages/SwapPage.tsx
+++ b/packages/dev-frontend/src/pages/SwapPage.tsx
@@ -1,0 +1,44 @@
+import { Container, Embed, useColorMode } from "theme-ui";
+import { PageHeading } from "../components/PageHeading";
+import { PageRow } from "../components/PageRow";
+import { Stability } from "../components/Stability/Stability";
+import { COIN } from "../utils/constants";
+import { useThresholdSelector } from "@liquity/lib-react";
+import { LiquityStoreState as ThresholdStoreState } from "@liquity/lib-base";
+
+export const SwapPage = (): JSX.Element => {
+
+  const selector = ({
+    symbol,
+  }: ThresholdStoreState) => ({
+    symbol,
+  });
+
+  const thresholdSelectorStores = useThresholdSelector(selector);
+  const thresholdStore = thresholdSelectorStores[0];
+  const store = thresholdStore?.store!;
+  const symbol = store.symbol;
+  const [colorMode] = useColorMode();
+  
+  return (
+    <Container
+    sx={{
+      minHeight: "32em"
+    }} variant="singlePage">
+      <PageHeading
+        heading="Swap"
+        description={`Exchange between ${ COIN } and ${ symbol } using Uniswap. Connect your wallet to get started.`}
+        link="https://github.com/Threshold-USD/dev"
+        isPoweredByBProtocol={true}
+      />
+      <Embed 
+        sx={{
+          height: "32em",
+          width: "95%",
+          mt: "2em"
+        }}
+        src={`https://app.uniswap.org/#/swap?inputCurrency=0x059969e68883900f651874C9648878dBa33f378C&outputCurrency=0x1091221BbF69ae494ae7d5fE7c794A361e89850c&theme=${colorMode == "default" ? "light" : "dark"}`}
+      />
+    </Container>
+  );
+};

--- a/packages/dev-frontend/src/pages/SwapPage.tsx
+++ b/packages/dev-frontend/src/pages/SwapPage.tsx
@@ -10,14 +10,17 @@ export const SwapPage = (): JSX.Element => {
 
   const selector = ({
     symbol,
+    collateralAddress,
   }: ThresholdStoreState) => ({
     symbol,
+    collateralAddress,
   });
 
   const thresholdSelectorStores = useThresholdSelector(selector);
   const thresholdStore = thresholdSelectorStores[0];
   const store = thresholdStore?.store!;
   const symbol = store.symbol;
+  const collateralAddress = store.collateralAddress;
   const [colorMode] = useColorMode();
   
   return (
@@ -37,7 +40,7 @@ export const SwapPage = (): JSX.Element => {
           width: "95%",
           mt: "2em"
         }}
-        src={`https://app.uniswap.org/#/swap?inputCurrency=0x059969e68883900f651874C9648878dBa33f378C&outputCurrency=0x1091221BbF69ae494ae7d5fE7c794A361e89850c&theme=${colorMode == "default" ? "light" : "dark"}`}
+        src={`https://app.uniswap.org/#/swap?inputCurrency=${collateralAddress}&outputCurrency=0x1091221BbF69ae494ae7d5fE7c794A361e89850c&theme=${colorMode == "default" ? "light" : "dark"}`}
       />
     </Container>
   );

--- a/packages/lib-base/etc/lib-base.api.md
+++ b/packages/lib-base/etc/lib-base.api.md
@@ -69,6 +69,8 @@ export class _CachedReadableLiquity<T extends unknown[]> implements _ReadableLiq
     // (undocumented)
     getStabilityDeposit(address?: string, ...extraParams: T): Promise<StabilityDeposit>;
     // (undocumented)
+    getStableAddress(...extraParams: T): Promise<string>;
+    // (undocumented)
     getSymbol(...extraParams: T): Promise<string>;
     // (undocumented)
     getTHUSDBalance(address?: string, ...extraParams: T): Promise<Decimal>;
@@ -314,6 +316,7 @@ export interface LiquityStoreBaseState {
     // @internal (undocumented)
     _riskiestTroveBeforeRedistribution: TroveWithPendingRedistribution;
     stabilityDeposit: StabilityDeposit;
+    stableAddress: string;
     symbol: string;
     thusdBalance: Decimal;
     thusdInStabilityPool: Decimal;
@@ -489,6 +492,7 @@ export interface ReadableLiquity {
     getPCVBalance(): Promise<Decimal>;
     getPrice(): Promise<Decimal>;
     getStabilityDeposit(address?: string): Promise<StabilityDeposit>;
+    getStableAddress(): Promise<string>;
     getSymbol(): Promise<string>;
     getTHUSDBalance(address?: string): Promise<Decimal>;
     getTHUSDInStabilityPool(): Promise<Decimal>;

--- a/packages/lib-base/src/LiquityStore.ts
+++ b/packages/lib-base/src/LiquityStore.ts
@@ -89,6 +89,9 @@ export interface LiquityStoreBaseState {
   /** BorrowersOperations contract collateral address. */
   collateralAddress: string;
 
+  /** TroveManager contract stable address. */
+  stableAddress: string;
+
   /** User's stability deposit. */
   stabilityDeposit: StabilityDeposit;
 
@@ -403,6 +406,8 @@ export abstract class LiquityStore<T = unknown> {
       symbol: baseState.symbol,
 
       collateralAddress: baseState.collateralAddress,
+
+      stableAddress: baseState.stableAddress,
 
       mintList: baseState.mintList,
 

--- a/packages/lib-base/src/ReadableLiquity.ts
+++ b/packages/lib-base/src/ReadableLiquity.ts
@@ -96,6 +96,11 @@ export interface ReadableLiquity {
   getCollateralAddress(): Promise<string>;
 
   /**
+   * Get the stablecoin address.
+   */
+  getStableAddress(): Promise<string>;
+
+  /**
    * Get the current state of a Stability Deposit.
    *
    * @param address - Address that owns the Stability Deposit.

--- a/packages/lib-base/src/_CachedReadableLiquity.ts
+++ b/packages/lib-base/src/_CachedReadableLiquity.ts
@@ -122,6 +122,13 @@ export class _CachedReadableLiquity<T extends unknown[]>
     );
   }
 
+  async getStableAddress(...extraParams: T): Promise<string> {
+    return (
+      this._cache.getStableAddress(...extraParams) ??
+      this._readable.getStableAddress(...extraParams)
+    );
+  }
+
   async getTHUSDInStabilityPool(...extraParams: T): Promise<Decimal> {
     return (
       this._cache.getTHUSDInStabilityPool(...extraParams) ??

--- a/packages/lib-ethers/etc/lib-ethers.api.md
+++ b/packages/lib-ethers/etc/lib-ethers.api.md
@@ -182,6 +182,8 @@ export class EthersLiquity implements ReadableEthersLiquity, TransactableLiquity
     // (undocumented)
     getStabilityDeposit(address?: string, overrides?: EthersCallOverrides): Promise<StabilityDeposit>;
     // (undocumented)
+    getStableAddress(overrides?: EthersCallOverrides): Promise<string>;
+    // (undocumented)
     getSymbol(overrides?: EthersCallOverrides): Promise<string>;
     // (undocumented)
     getTHUSDBalance(address?: string, overrides?: EthersCallOverrides): Promise<Decimal>;
@@ -529,6 +531,8 @@ export class ReadableEthersLiquity implements ReadableLiquity {
     getRedemptionRate(overrides?: EthersCallOverrides): Promise<Decimal>;
     // (undocumented)
     getStabilityDeposit(address?: string, overrides?: EthersCallOverrides): Promise<StabilityDeposit>;
+    // (undocumented)
+    getStableAddress(overrides?: EthersCallOverrides): Promise<string>;
     // (undocumented)
     getSymbol(overrides?: EthersCallOverrides): Promise<string>;
     // (undocumented)

--- a/packages/lib-ethers/src/BlockPolledLiquityStore.ts
+++ b/packages/lib-ethers/src/BlockPolledLiquityStore.ts
@@ -110,6 +110,7 @@ export class BlockPolledLiquityStore extends LiquityStore<BlockPolledLiquityStor
       _riskiestTroveBeforeRedistribution: this._getRiskiestTroveBeforeRedistribution({ blockTag }),
       symbol: this._readable.getSymbol({ blockTag }),
       collateralAddress: this._readable.getCollateralAddress({ blockTag }),
+      stableAddress: this._readable.getStableAddress({ blockTag }),
       mintList: this._readable.checkMintList({ blockTag }),
       bammAllowance: Decimal.ZERO, // this._readable.getBammAllowance({ blockTag }),
       isStabilityPools: this._readable.isStabilityPools({ blockTag }),

--- a/packages/lib-ethers/src/EthersLiquity.ts
+++ b/packages/lib-ethers/src/EthersLiquity.ts
@@ -238,6 +238,11 @@ export class EthersLiquity implements ReadableEthersLiquity, TransactableLiquity
     return this._readable.getCollateralAddress(overrides);
   }
 
+  /** {@inheritDoc @liquity/lib-base#ReadableLiquity.getStableAddress} */
+  getStableAddress(overrides?: EthersCallOverrides): Promise<string> {
+    return this._readable.getStableAddress(overrides);
+  }
+
   /** {@inheritDoc @liquity/lib-base#ReadableLiquity.getStabilityDeposit} */
   getStabilityDeposit(address?: string, overrides?: EthersCallOverrides): Promise<StabilityDeposit> {
     return this._readable.getStabilityDeposit(address, overrides);

--- a/packages/lib-ethers/src/ReadableEthersLiquity.ts
+++ b/packages/lib-ethers/src/ReadableEthersLiquity.ts
@@ -328,6 +328,13 @@ export class ReadableEthersLiquity implements ReadableLiquity {
     return borrowerOperations.collateralAddress({ ...overrides });
   }
 
+  /** {@inheritDoc @liquity/lib-base#ReadableLiquity.getStableAddress} */
+  getStableAddress(overrides?: EthersCallOverrides): Promise<string> {
+    const { troveManager } = _getContracts(this.connection);
+
+    return troveManager.thusdToken({ ...overrides });
+  }
+
   /** {@inheritDoc @liquity/lib-base#ReadableLiquity.getBammDeposit} */
   async getBammDeposit(
     address?: string,
@@ -728,6 +735,12 @@ class _BlockPolledReadableEthersLiquity
     return this._blockHit(overrides)
       ? this.store.state.collateralAddress
       : this._readable.getCollateralAddress(overrides);
+  }
+
+  async getStableAddress(
+    overrides?: EthersCallOverrides
+  ): Promise<string> {
+    return this._readable.getStableAddress(overrides);
   }
 
   async getStabilityDeposit(

--- a/packages/lib-subgraph/src/SubgraphLiquity.ts
+++ b/packages/lib-subgraph/src/SubgraphLiquity.ts
@@ -258,6 +258,10 @@ export class SubgraphLiquity implements ReadableLiquity, ObservableLiquity {
     throw new Error("Method not implemented.");
   }
 
+  getStableAddress(): Promise<string> {
+    throw new Error("Method not implemented.");
+  }
+
   getStabilityDeposit(address?: string): Promise<StabilityDeposit> {
     throw new Error("Method not implemented.");
   }


### PR DESCRIPTION
I initially tried using the [Uniswap Widget](https://docs.uniswap.org/sdk/swap-widget/guides/getting-started#json-rpc-endpoint), however it's super buggy and the workarounds were only for Next.js apps.

Instead I'm using the iframe approach. It doesn't provide nearly as many customization options and unfortunately requires the extra step of connecting the wallet, but it's something that works for now.

<img width="1058" alt="image" src="https://github.com/LiquidEnergyDollar/stability-protocol/assets/11261382/7f8200d7-b681-4325-b5b6-cac82cb02e3d">
